### PR TITLE
fix(terraform): update required_version to 1.3

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -9,5 +9,5 @@ terraform {
       version = "3.7.1"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
Update the required Terraform version from 1.1.9 to 1.3 to ensure 
compatibility with the latest features and improvements. This change 
enhances the stability and performance of the Terraform infrastructure.